### PR TITLE
[REFACT] 지원자 갱신 기능(구글시트 연동) 리팩토링

### DIFF
--- a/src/app/applicant/api/controller/applicant_controller.js
+++ b/src/app/applicant/api/controller/applicant_controller.js
@@ -1,10 +1,5 @@
-const answerService = require('../../service/answer_service.js');
-const applicantService = require('../../service/applicant_service.js');
-const applicantStatusService = require('../../service/applicant_status_service.js');
-const questionService = require('../../service/question_service.js');
 const resumeService = require('../../service/resume_service.js');
-const teamService = require('../../../team/service/team_service.js');
-const spreadsheetUtil = require('../../../../util/spreadsheet.js');
+const applicantService = require('../../service/applicant_service.js');
 
 const getResume = async (req, res, next) => {
   try {
@@ -20,110 +15,6 @@ const getResume = async (req, res, next) => {
     next(err);
   }
 };
-
-const getApplicantFromSheet = async (req, res) => {
-
-  console.log('asdfsdf');
-  const teams = await teamService.getTeams();
-
-
-  const targetList = [];
-  for (const team of teams) {
-    const sheetLink = team.getDataValue('sheets_link');
-    const splits = sheetLink.split('/');
-    if (!!splits[5]) {
-      targetList.push({
-        teamId: team.getDataValue('id'),
-        spreadId: splits[5]
-      });
-    }
-  }
-
-  await answerService.clearAnswers();
-  await questionService.clearQuestion();
-  await applicantService.clearApplicants();
-
-
-
-  for (const target of targetList) {
-    // Update questions
-    const headerList = await spreadsheetUtil.getHeaderList(target.spreadId);
-    const updateQuestionResult = await questionService.updateQuestion(target, headerList);
-    // console.log(updateQuestionResult);
-
-
-    // Update applicant
-    const applicantTargetList = [];
-    const dataList = await spreadsheetUtil.getDataList(target.spreadId);
-
-    for (let j = 0; j < dataList.length; j++) {
-      const obj = {
-        teams_id: target.teamId,
-        name: dataList[j][2],
-        email: dataList[j][1],
-        phone: dataList[j][3],
-      };
-      applicantTargetList.push(obj);
-    }
-    // console.log(applicantTargetList);
-
-    for (let k = 0; k < applicantTargetList.length; k++) {
-      const applicantUpdateResult = await applicantService.updateApplicant(applicantTargetList[k]);
-      const applicantId = applicantUpdateResult.getDataValue('id');
-      for (let z = 0; z < updateQuestionResult.length; z++) {
-        const qId = updateQuestionResult[z].getDataValue('id');
-
-        // console.log(qId);
-        // console.log(applicantId);
-
-        await answerService.updateAnswer(qId, applicantId, dataList[k][z]);
-
-      }
-    }
-
-    // res.status(200).send({});
-    const result222 = await applicantStatusService.getApplicants('ADMIN');
-    res.status('200')
-    .json({
-      data: result222,
-    });
-
-    // for (let j = 0; j < dataList.length; j++) {
-    //   const qId = updateQuestionResult[j].getDataValue('id');
-    //   console.log(qId);
-    // }
-
-
-
-    // await applicantService.updateApplicant(applicantTargetList);
-
-
-
-    // Update answer
-
-    // await
-
-
-  }
-
-
-  // console.log(targetList);
-};
-
-// router.route('/')
-//   .get(async (req, res, next) => {
-//     try {
-//       const result = await applicantStatusService.getApplicants('ADMIN');
-//       res.status('200')
-//         .json({
-//           data: result,
-//         });
-//     } catch (err) {
-//       console.error(err);
-//       next(err);
-//     }
-//   });
-//
 
 const changeStatus = async (req, res, next) => {
   const applicantId = req.params.id;

--- a/src/app/applicant/api/controller/applicant_status_controller.js
+++ b/src/app/applicant/api/controller/applicant_status_controller.js
@@ -1,4 +1,5 @@
 const applicantStatusService = require('../../service/applicant_status_service.js');
+const resumeFromService = require('../../service/resume_from_service.js');
 
 const getApplicants = async (req, res, next) => {
   const {role: role} = req.decoded;
@@ -63,9 +64,24 @@ const searchByStatus = async (req, res, next) => {
   }
 };
 
+const getApplicantFromSheet = async (req, res) => {
+  try {
+    const {role: role} = req.decoded;
+    await resumeFromService.refreshFrom(role);
+    res.status('200')
+      .json({
+        data: "success",
+      });
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
+};
+
 module.exports = {
   getApplicants,
   searchByValue,
   searchByTeam,
   searchByStatus,
+  getApplicantFromSheet,
 };

--- a/src/app/applicant/api/router/applicant_router.js
+++ b/src/app/applicant/api/router/applicant_router.js
@@ -2,7 +2,6 @@ const router = require('express').Router();
 
 const applicantController = require('../controller/applicant_controller.js');
 
-router.get('/', applicantController.getApplicantFromSheet);
 router.get('/:id', applicantController.getResume)
 router.patch('/:id', applicantController.changeStatus);
 router.patch('/', applicantController.changeListStatus);

--- a/src/app/applicant/api/router/applicant_status_router.js
+++ b/src/app/applicant/api/router/applicant_status_router.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 
 const applicantStatusController = require('../controller/applicant_status_controller.js');
 
+router.get('/refresh', applicantStatusController.getApplicantFromSheet);
 router.get('/', applicantStatusController.getApplicants);
 router.get('/search', applicantStatusController.searchByValue);
 router.get('/teams/:teamsId', applicantStatusController.searchByTeam);

--- a/src/app/applicant/infrastructure/google_sheet.js
+++ b/src/app/applicant/infrastructure/google_sheet.js
@@ -1,0 +1,101 @@
+const serviceAccount = require('../../../../config/mash-up-admin-dev-8deb0d42c2ef.json');
+const {GoogleSpreadsheet,GoogleSpreadsheetWorksheet} = require('google-spreadsheet');
+const moment = require('moment');
+
+const fillZero = (number, width) => {
+  number = number + '';
+  return number.length >= width ?
+      number :
+      new Array(width - number.length + 1).join('0') + number;
+};
+
+/**
+ * @description Convert '2020. 7. 25 오후 11:10:54' to unix time stamp
+ * @param {string} stringTimeStamp
+ * @returns {number}
+ */
+const convertStringToUnixTimeStamp = stringTimeStamp => {
+  if (!stringTimeStamp) {
+    throw Error('Need string time stamp');
+  }
+  const splits = stringTimeStamp.split(' ');
+  if (splits.length !== 5) {
+    throw Error('Unknown time stamp format');
+  }
+  const year = splits[0].slice(0, -1);
+  const month = fillZero(splits[1].slice(0, -1), 2);
+  const day = fillZero(splits[2], 2);
+  const isPM = splits[3] === '오후';
+  const timeSplits = splits[4].split(':');
+  const hours = fillZero((Number(timeSplits[0]) + (isPM ? 12 : 0)) + '', 2);
+  const minutes = fillZero(timeSplits[1], 2);
+  const seconds = fillZero(timeSplits[2], 2);
+  const momentTime = moment(
+      `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`,
+      'YYYY-MM-DD HH:mm"ss');
+  return momentTime.valueOf();
+};
+
+/**
+ * @param {string} sheetId
+ * @returns {Promise<GoogleSpreadsheetWorksheet>}
+ */
+const getSheet = async sheetId => {
+  const doc = new GoogleSpreadsheet(sheetId);
+  const authErr = await doc.useServiceAccountAuth(serviceAccount); // TODO(sanghee): 매번 인증이 아닌 한번만 인증할 수 있는 방법
+  if (authErr) {
+    throw Error('Google useServiceAccountAuth error');
+  }
+  await doc.loadInfo();
+  return doc.sheetsByIndex[0];
+};
+
+/**
+ * @param {string} sheetId
+ * @returns {Promise<[string]>}
+ */
+const getHeaderList = async sheetId => {
+  const sheet = await getSheet(sheetId);
+  await sheet.loadHeaderRow();
+  return sheet.headerValues;
+};
+
+/**
+ * @param {string} sheetId
+ * @param {number} [from=1]
+ * @param {number} [to=-1]
+ * @returns {Promise<[(number|string)]>}
+ */
+const getDataList = async (sheetId, from = 1, to = -1) => {
+  const sheet = await getSheet(sheetId);
+  const rowList = await sheet.getRows(
+      {
+        offset: 0,
+        limit: 1000, // TODO(sanghee): from ~ to
+      },
+  );
+
+  if (rowList.length === 0) {
+    return [];
+  }
+
+  const headerLength = rowList[0]._sheet.headerValues.length;
+  const dataList = [];
+
+  // TODO(sanghee): Need to validate header 1, 2, 3, 4 (timestamp, email, name, birth)
+
+  for (const row of rowList) {
+    const data = Object.assign([], row._rawData);
+    while (data.length < headerLength) {
+      data.push('');
+    }
+    data[0] = convertStringToUnixTimeStamp(data[0]);
+    dataList.push(data);
+  }
+  return dataList;
+};
+
+module.exports = {
+  getHeaderList,
+  getDataList,
+};

--- a/src/app/applicant/service/answer_service.js
+++ b/src/app/applicant/service/answer_service.js
@@ -6,7 +6,7 @@ const clearAnswers = async () => {
   return result;
 };
 
-const updateAnswer = async (qId, applicantId, content) => {
+const createAnswer = async (qId, applicantId, content) => {
   const result = await Answer.create({
     questions_id: qId,
     applicants_id: applicantId,
@@ -18,5 +18,5 @@ const updateAnswer = async (qId, applicantId, content) => {
 
 module.exports = {
   clearAnswers,
-  updateAnswer,
+  createAnswer,
 };

--- a/src/app/applicant/service/applicant_service.js
+++ b/src/app/applicant/service/applicant_service.js
@@ -9,7 +9,7 @@ const clearApplicants = async () => {
   return result;
 };
 
-const updateApplicant = async obj => {
+const createApplicant = async obj => {
   const result = await Applicant.create({
     teams_id: obj.teams_id,
     application_status: APPLICATION_STATUS.APPLICATION_COMPLETION,
@@ -72,7 +72,7 @@ const changeListStatus = async (role, applicantIds, applicantionStatus) => {
 
 module.exports = {
   clearApplicants,
-  updateApplicant,
+  createApplicant,
   changeStatus,
   changeListStatus,
 };

--- a/src/app/applicant/service/question_service.js
+++ b/src/app/applicant/service/question_service.js
@@ -6,7 +6,7 @@ const clearQuestion = async () => {
   return result;
 };
 
-const updateQuestion = async (target, headerList) => {
+const createQuestion = async (target, headerList) => {
   const list = [];
 
   for (let i = 0; i < headerList.length; i++) {
@@ -24,5 +24,5 @@ const updateQuestion = async (target, headerList) => {
 
 module.exports = {
   clearQuestion,
-  updateQuestion,
+  createQuestion,
 };

--- a/src/app/applicant/service/resume_from_service.js
+++ b/src/app/applicant/service/resume_from_service.js
@@ -1,0 +1,116 @@
+const answerService = require('./answer_service.js');
+const questionService = require('./question_service.js');
+const teamService = require('../../team/service/team_service');
+const googleSheet = require('../infrastructure/google_sheet.js');
+const db = require('../../../common/model/sequelize');
+const { clearApplicants } = require('./applicant_service.js');
+
+const REGS = '/'
+const SHEETS_LINK = 'sheets_link';
+const ID = 'id';
+const SHEET_INDEX = 5;
+const NAME_INDEX = 2;
+const EMAIL_INDEX = 1;
+const PHONE_INDEX = 3;
+
+const refreshFrom = async (role) => {
+  if(!role == ROLE.ADMIN) {
+    const error = new Error('No Atuthentification');
+    error.status = 403;
+    throw error;
+  }
+  
+  const t = await db.sequelize.transaction();
+  try {
+    await clearApplicants();
+
+    const teams = await teamService.getTeams();
+    const targetList = await parsingToTarget(teams);
+        
+    await generateApplicants(targetList);
+    
+    await t.commit();
+    } catch (error) {
+      console.log(error);
+      await t.rollback();
+  }
+    // for (let j = 0; j < dataList.length; j++) {
+    //   const qId = updateQuestionResult[j].getDataValue('id');
+    //   console.log(qId);
+    // }
+    // await applicantService.updateApplicant(applicantTargetList);
+    // Update answer
+    // await
+  // console.log(targetList);
+}
+
+const parsingToTarget = async (teams) => {
+  const targetList = [];
+
+  for (const team of teams) {
+    const sheetLink = team.getDataValue(SHEETS_LINK);
+    const splits = sheetLink.split(REGS);
+    if (!!splits[SHEET_INDEX]) {
+      targetList.push({
+        teamId: team.getDataValue(ID),
+        spreadId: splits[SHEET_INDEX]
+      });
+    }
+  }
+  return targetList;
+}
+
+const clearApplicants = async () => {
+  await answerService.clearAnswers();
+  await questionService.clearQuestion();
+  await applicantService.clearApplicants();
+}
+
+const generateApplicants = async (targetList) => {
+  for (const target of targetList) {
+    // Update questions
+    const headerList = await googleSheet.getHeaderList(target.spreadId);
+    const updateQuestionResult = await questionService.createQuestion(target, headerList);
+    // console.log(updateQuestionResult);
+  
+    // Update applicant
+    const dataList = await googleSheet.getDataList(target.spreadId);
+    const applicantTargetList = parsingToApplicantTarget(dataList);
+
+    // console.log(applicantTargetList);
+    generateAnswer(applicantTargetList, updateQuestionResult, dataList)
+  }
+}
+
+
+const parsingToApplicantTarget = async (dataList) => {
+  const applicantTargetList = [];
+
+  for (let j = 0; j < dataList.length; j++) {
+    const obj = {
+      teams_id: target.teamId,
+      name: dataList[j][NAME_INDEX],
+      email: dataList[j][EMAIL_INDEX],
+      phone: dataList[j][PHONE_INDEX],
+    };
+    applicantTargetList.push(obj);
+  }
+  return applicantTargetList;
+}
+
+const generateAnswer = async (applicantTargetList, updateQuestionResult, dataList) => {
+  for (let k = 0; k < applicantTargetList.length; k++) {
+    const applicantUpdateResult = await applicantService.createApplicant(applicantTargetList[k]);
+    const applicantId = applicantUpdateResult.getDataValue(ID);
+    for (let z = 0; z < updateQuestionResult.length; z++) {
+      const qId = updateQuestionResult[z].getDataValue(ID);
+        // console.log(qId);
+        // console.log(applicantId);
+      await answerService.createAnswer(qId, applicantId, dataList[k][z]);
+    }
+  }
+}
+
+module.exports = {
+  refreshFrom,
+};


### PR DESCRIPTION
- 지원자리스트 갱신이 지원자 현황 컨트롤러에서 이루어지는게 맞다고 생각하여 url과 로직을 지원자현황으로 이동하였습니다.
- 구글 시트와 연동하여 가져오는 부분은 util이라기 보다는 직접적인 인프라와 연동하는 매우 저수준의 모듈이라고 생각하여 infra 패키지로 이동시켰습니다.(한곳에만 쓰이고 어플리케이션 로직의 util로는 보기가 어려울꺼 같다고 생각하였습니다.)
- 컨트롤러가 많은 서비스를 가져서 사용하고 다른 로직에서 해당 서비스들을 사용하지 않기 때문에 서비스를 하나 만들어 서비스가 서비스들을 호출하는 방식으로 변경하였습니다.
- 하나의 로직에서 많은 스크립트들이 동작하고 있기 때문에 가독성있게 함수들로 각각 분리하여 호출하는 식으로 전체적인 흐름은 파악할수있게 하였습니다.

resolve #41 